### PR TITLE
Improve VN UI and fade transitions

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -115,6 +115,8 @@ class VNEngine {
     this.nm = document.getElementById("vn-name");
     this.tx = document.getElementById("vn-text");
     this.ch = document.getElementById("vn-choices");
+    this.ui = document.getElementById("vn-ui");
+    this.fadeIn(this.ui);
 
     document.addEventListener("click", e => {
       if (this.paused) return;
@@ -129,8 +131,8 @@ class VNEngine {
   }
 
   /* --- helpers --- */
-  fadeOut(el) { el.classList.add("hidden"); }
-  fadeIn(el)  { el.classList.remove("hidden"); }
+  fadeOut(el) { el.style.opacity = 0; }
+  fadeIn(el)  { el.style.opacity = 1; }
 
   setImage(el, src) {
     if (!src) { this.fadeOut(el); return; }              // спрятать элемент

--- a/engine.js
+++ b/engine.js
@@ -59,6 +59,7 @@ function parseStory(raw) {
     if (line.startsWith("show "))  { const id = line.slice(5).trim();
       script.push({ type: "show", sprite: sprites[id] || id }); continue; }
     if (line.startsWith("jump "))  { script.push({ type: "jump", label: line.slice(5).trim() }); continue; }
+    if (line.startsWith("call "))  { script.push({ type: "call", label: line.slice(5).trim() }); continue; }
 
     /* return;  -> конец игры */
     if (/^return\s*;?\s*$/.test(line)) { script.push({ type: "return" }); continue; }
@@ -78,14 +79,15 @@ function parseStory(raw) {
         const optPad = ind(rawOpt), t = rawOpt.trimStart().match(/^"(.+)"\s*:\s*$/);
         if (!t) { i++; continue; }
         const text = t[1]; i++;
-        let jump = null;
+        let jump = null, isCall = false;
         while (i < ls.length) {
           const inr = noComment(ls[i]); if (!inr.trim()) { i++; continue; }
           if (ind(inr) <= optPad) break;
-          const jm = inr.trimStart().match(/^jump\s+(\w+)$/); if (jm) jump = jm[1];
+          const jm = inr.trimStart().match(/^(jump|call)\s+(\w+)$/);
+          if (jm) { isCall = jm[1] === "call"; jump = jm[2]; }
           i++;
         }
-        opts.push({ text, jump });
+        opts.push({ text, jump, call: isCall });
       }
       script.push({ type: "choice", options: opts });
       continue;
@@ -106,6 +108,7 @@ class VNEngine {
     this.script = script; this.assetsPath = assetsPath;
     this.labels = Object.fromEntries(script.map((c, i) => c.type === "label" ? [c.name, i] : null).filter(Boolean));
     this.pos = 0; this.justJumped = true; this.paused = false;
+    this.stack = [];
 
     this.isTyping = false; this.fullText = ""; this.timer = null;
 
@@ -147,6 +150,14 @@ class VNEngine {
 
   next() { this.pos++; this.run(); }
   jump(l) { if (this.labels[l] != null) { this.pos = this.labels[l]; this.justJumped = true; this.run(); } }
+  call(l) {
+    if (this.labels[l] != null) {
+      this.stack.push(this.pos + 1);
+      this.pos = this.labels[l];
+      this.justJumped = true;
+      this.run();
+    }
+  }
 
   run() {
     if (this.paused) return;
@@ -158,10 +169,15 @@ class VNEngine {
       case "say":    this.showSay(c);                           break;
       case "choice": this.showChoices(c.options);               break;
       case "jump":   this.jump(c.label);                        break;
+      case "call":   this.call(c.label);                        break;
       case "label":
         if (this.justJumped) { this.justJumped = false; this.next(); }
+        else if (this.stack.length) { this.pos = this.stack.pop(); this.run(); }
         break;
-      case "return": this.endGame();                            break;
+      case "return":
+        if (this.stack.length) { this.pos = this.stack.pop(); this.justJumped = false; this.next(); }
+        else this.endGame();
+        break;
     }
   }
 
@@ -191,7 +207,11 @@ class VNEngine {
       b.textContent = o.text;
       b.onclick = () => {
         this.ch.innerHTML = "";
-        o.jump ? this.jump(o.jump) : this.next();
+        if (o.jump) {
+          o.call ? this.call(o.jump) : this.jump(o.jump);
+        } else {
+          this.next();
+        }
       };
       this.ch.appendChild(b);
     });

--- a/index.html
+++ b/index.html
@@ -8,8 +8,8 @@
 <body>
 
   <!------- СЦЕНА ------->
-  <img id="vn-background" class="hidden" />
-  <img id="vn-sprite"     class="hidden" />
+  <img id="vn-background" />
+  <img id="vn-sprite"     />
 
   <!------- UI текста/выборов ------->
   <div id="vn-ui">

--- a/story.txt
+++ b/story.txt
@@ -20,17 +20,19 @@ script:
         a "Я Анна."
         menu(a "А ты?"):
             "Меня зовут игрок.":
-                jump player
+                call player
             "Я не знаю.":
-                jump idk
+                call idk
 
     label player:
         e "Я игрок."
         a "О как..."
+        return
 
     label idk:
         e "Не знаю..."
         a "Ну дела..."
+        return
 
     a "Ладно, пофиг!"
     "Она улыбнулась."

--- a/story.txt
+++ b/story.txt
@@ -4,10 +4,10 @@ define characters:
     e = "Я"
 
 define sprites:
-    anna = "images/anna.png"
+    anna = "anna.png"
 
 define images:
-    background1 = "images/bg1.jpg"
+    background1 = "bg1.jpg"
 
 script:
     label start:

--- a/styles.css
+++ b/styles.css
@@ -31,8 +31,8 @@ html,body{margin:0;height:100%;overflow:hidden;font-family:sans-serif;background
   height:5em;overflow-y:auto;line-height:1.4;
   padding:10px;background:rgba(0,0,0,.5);border-radius:6px;
 }
-#vn-choices{margin-top:12px;display:flex;flex-direction:column;gap:8px}
-.vn-choice{background:#444;border:none;padding:10px;color:#fff;cursor:pointer;font-size:1rem;transition:background .3s}
+#vn-choices{margin-top:12px;display:flex;flex-direction:column;gap:8px;align-items:center}
+.vn-choice{background:#444;border:none;padding:10px;color:#fff;cursor:pointer;font-size:1rem;transition:background .3s;min-width:200px}
 .vn-choice:hover{background:#666}
 
 /* --- оверлеи главного / пауза-меню ---*/

--- a/styles.css
+++ b/styles.css
@@ -4,24 +4,33 @@ html,body{margin:0;height:100%;overflow:hidden;font-family:sans-serif;background
 /* --- фон сцены 1920×1080 -------------*/
 #vn-background{
   position:absolute;top:0;left:0;width:100%;height:100%;
-  object-fit:cover;transition:opacity .5s;
+  object-fit:cover;transition:opacity .5s;opacity:0;
 }
 
 /* --- спрайт (ровно 1080 px высоты) ---*/
 #vn-sprite{
   position:absolute;bottom:0;left:50%;transform:translateX(-50%);
   height:100%;width:auto;object-fit:contain;
-  pointer-events:none;transition:opacity .5s;
+  pointer-events:none;transition:opacity .5s;opacity:0;
 }
 
 /* --- нижняя панель текста -----------*/
 #vn-ui{
-  position:absolute;bottom:0;left:0;width:100%;
+  position:absolute;bottom:0;left:50%;transform:translateX(-50%);
+  width:90%;max-width:960px;
   background:rgba(0,0,0,.6);color:#fff;
   padding:20px;box-sizing:border-box;
+  border-top-left-radius:10px;border-top-right-radius:10px;
+  transition:opacity .5s;opacity:1;
 }
-#vn-name{font-weight:700;margin-bottom:8px}
-#vn-text{min-height:4em;line-height:1.4}
+#vn-name{
+  font-weight:700;margin-bottom:8px;height:1.4em;line-height:1.4em;
+  padding:0 12px;background:rgba(0,0,0,.75);border-radius:6px;
+}
+#vn-text{
+  height:5em;overflow-y:auto;line-height:1.4;
+  padding:10px;background:rgba(0,0,0,.5);border-radius:6px;
+}
 #vn-choices{margin-top:12px;display:flex;flex-direction:column;gap:8px}
 .vn-choice{background:#444;border:none;padding:10px;color:#fff;cursor:pointer;font-size:1rem;transition:background .3s}
 .vn-choice:hover{background:#666}
@@ -30,10 +39,15 @@ html,body{margin:0;height:100%;overflow:hidden;font-family:sans-serif;background
 .overlay{
   position:absolute;top:0;left:0;width:100%;height:100%;
   display:flex;flex-direction:column;justify-content:center;align-items:center;
-  gap:24px;background:rgba(0,0,0,.85);color:#fff;text-align:center;
+  gap:24px;background:linear-gradient(rgba(0,0,0,.9),rgba(0,0,0,.7));color:#fff;text-align:center;
+  font-family:sans-serif;
 }
-.overlay button{padding:12px 28px;font-size:1.1rem;cursor:pointer;border:none;background:#555;color:#fff}
-.overlay button:hover{background:#777}
+.overlay button{padding:12px 36px;font-size:1.2rem;cursor:pointer;border:none;background:#333;color:#fff;border-radius:8px}
+.overlay button:hover{background:#555}
+
+.overlay h1,.overlay h2{margin:0;text-shadow:0 0 6px #000}
+.overlay h1{font-size:3rem}
+.overlay h2{font-size:2rem}
 
 /* --- утилита скрытия ---------------*/
 .hidden{display:none}


### PR DESCRIPTION
## Summary
- fix asset paths to use repo root
- implement fade transitions via opacity
- keep textbox and namebox size static and restyle them
- refresh menu design

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859b852b7e8832ca9de62e609b74091